### PR TITLE
Allow type module scripts by adding the suffix '.module' to the URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 - can dumbly check already inserted tags at load time
 - may use a fallback url on error (only for js files and with error events compatible browsers)
 - may register error handlers (only for js files and with error events compatible browsers)
+- can load javascripts modules 
 
 ## examples
 
@@ -90,6 +91,15 @@ You can define this fallback url parameter like you define ids. The difference i
 			console.log('error loading', url); // <- will print "error loading missingFile.js"
 		})
 	;
+</script>
+```
+
+### load a module
+to load javascript modules you have to add the suffix `.module` to the url, this will load the script with the `type` set on `module`
+
+```html
+<script src="l.js">
+    ljs.load('myModuleLib.js.module',function(){ /* your callback here */});
 </script>
 ```
 

--- a/l.js
+++ b/l.js
@@ -29,6 +29,7 @@
 		, readyState = 'readyState'
 		, onreadystatechange = 'onreadystatechange'
 		, typeJS = 'text/javascript'
+		, typeModule = 'module'
 		, scriptStr = 'script'
 		, header  = D[getElementsByTagName]("head")[0] || D.documentElement
 		, aliases = {}
@@ -61,7 +62,7 @@
 			//-- keep trace of header as we will make multiple access to it
 			,urlParse = function(url){
 				var parts={}; // u => url, i => id, f = fallback
-				parts.u = url.replace(/#(=)?([^#]*)?/g,function(m,a,b){ parts[a?'f':'i'] = b; return '';});
+				parts.u = url.replace(/#(=)?([^#]*)?|(\.module)/g,function(m,a,b,c){parts[a?'f':'i'] = b;parts['m'] = !!c;return '';});
 				return parts;
 			}
 			,load = function(loader, url,cb){
@@ -90,6 +91,7 @@
 				,loadjs: function(url,cb){
 					var parts = urlParse(url);
 					var onError = function(url) {for(var i=0, l=errorHandlers.length;i<l;i++){errorHandlers[i](url)}};
+					var type = parts.m ? typeModule : typeJS;
 					url = parts.u;
 					if( loaded[url] === true ){ // already loaded exec cb if any
 						cb && cb();
@@ -104,11 +106,11 @@
 					loaded[url] = (function(cb){ return function(){loaded[url]=true; cb && cb();};})(cb);
 					cb = function(){ loaded[url](); };
 
-					appendElmt(scriptStr,{type:typeJS,src:url,id:parts.i,onerror:function(error){
+					appendElmt(scriptStr,{type:type,src:url,id:parts.i,onerror:function(error){
 						onError(url);
 						var c = error.currentTarget;
 						c.parentNode.removeChild(c);
-						appendElmt(scriptStr,{type:typeJS,src:parts.f,id:parts.i, onerror:function(){onError(parts.f)}},cb);
+						appendElmt(scriptStr,{type:type,src:parts.f,id:parts.i, onerror:function(){onError(parts.f)}},cb);
 					}},cb);
 					return loader;
 				}


### PR DESCRIPTION
Adding the suffix `.module` to an URL will load the scripts with the type `module` instead `text/javascript` which is the default, this is because some applications use `export` to expose their classes.
Example:
`ljs.load('myLib.js.module',function(){ /* your callback here */});`
